### PR TITLE
update submission with new keys including state, stateName, party, di…

### DIFF
--- a/scripts/views/newEventView.js
+++ b/scripts/views/newEventView.js
@@ -420,7 +420,7 @@
           TownHall.currentEvent.stateName = mocdata.stateName;
         }
         if (mocdata.type === 'sen') {
-          TownHall.currentEvent.district = "Senate";
+          TownHall.currentEvent.district = null;
         } else if (mocdata.type === 'rep') {
           var zeropadding = "00";
           var updatedDistrict = zeropadding.slice(0, zeropadding.length - mocdata.district.length) + mocdata.district;


### PR DESCRIPTION
This PR updates every town hall event submission to include the following properties:
-stateName
-party
-district
-state

This update does not delete our original object keys, so there will be duplicate values for now. 
(Ex. an event type will have both "District" and "district" properties, so other parts of Town Hall won't be affected)