### PR TITLE
Update/moc db requests

### DIFF
--- a/src/containers/UserToolkit/index.js
+++ b/src/containers/UserToolkit/index.js
@@ -281,12 +281,12 @@ UserToolkit.propTypes = {
   addMemberLink: PropTypes.func.isRequired,
   eventCount: PropTypes.number,
   currentTownHall: PropTypes.shape({}).isRequired,
-  setSelectedMember: PropTypes.func.isRequired,
   peopleDataUrl: PropTypes.string.isRequired,
   resetAllData: PropTypes.func.isRequired,
   requestPersonDataById: PropTypes.func.isRequired,
-  selectedMemberLinks: PropTypes.arrayOf(PropTypes.shape({})),
   setSelectedLink: PropTypes.func.isRequired,
+  setSelectedMember: PropTypes.func.isRequired,
+  selectedMemberLinks: PropTypes.arrayOf(PropTypes.shape({})),
   submitMetaData: PropTypes.func.isRequired,
   uid: PropTypes.string,
   userDisplayName: PropTypes.string,
@@ -301,25 +301,25 @@ UserToolkit.defaultProps = {
 };
 
 const mapStateToProps = state => ({
-  userMocs: userStateBranch.selectors.getUserMOCs(state),
-  selectedMoc: selectionStateBranch.selectors.getSelectedUserMoc(state),
-  selectedMemberLinks: selectionStateBranch.selectors.getSelectedMemberLinks(state),
   currentTownHall: townHallStateBranch.selectors.getTownHall(state),
+  eventCount: userStateBranch.selectors.getEventCount(state),
   peopleDataUrl: selectionStateBranch.selectors.getPeopleDataUrl(state),
+  selectedLink: lawMakerStateBranch.selectors.getSelectedLink(state),
+  selectedMemberLinks: selectionStateBranch.selectors.getSelectedMemberLinks(state),
+  selectedMoc: selectionStateBranch.selectors.getSelectedUserMoc(state),
   userDisplayName: userStateBranch.selectors.getUserName(state),
   uid: userStateBranch.selectors.getUid(state),
-  selectedLink: lawMakerStateBranch.selectors.getSelectedLink(state),
-  eventCount: userStateBranch.selectors.getEventCount(state),
+  userMocs: userStateBranch.selectors.getUserMOCs(state),
 });
 
 const mapDispatchToProps = dispatch => ({
-  requestPersonDataById: (peopleDataUrl, id) => dispatch(lawMakerStateBranch.actions.requestPersonDataById(peopleDataUrl, id)),
   addMemberLink: payload => dispatch(lawMakerStateBranch.actions.addMemberLink(payload)),
-  editMemberLink: payload => dispatch(lawMakerStateBranch.actions.editMemberLink(payload)),
   deleteMemberLink: payload => dispatch(lawMakerStateBranch.actions.deleteMemberLink(payload)),
+  editMemberLink: payload => dispatch(lawMakerStateBranch.actions.editMemberLink(payload)),
+  requestPersonDataById: (peopleDataUrl, id) => dispatch(lawMakerStateBranch.actions.requestPersonDataById(peopleDataUrl, id)),
+  setSelectedLink: payload => dispatch(lawMakerStateBranch.actions.setSelectedLink(payload)),
   setSelectedMember: member => dispatch(lawMakerStateBranch.actions.setSelectedMember(member)),
   submitMetaData: payload => dispatch(townHallStateBranch.actions.saveMetaData(payload)),
-  setSelectedLink: payload => dispatch(lawMakerStateBranch.actions.setSelectedLink(payload)),
 });
 
 

--- a/src/containers/UserToolkit/index.js
+++ b/src/containers/UserToolkit/index.js
@@ -53,9 +53,9 @@ class UserToolkit extends React.Component {
 
   selectMoc(moc) {
     const {
-      getSelectedMemberInfo,
+      setSelectedMember,
     } = this.props;
-    getSelectedMemberInfo(moc);
+    setSelectedMember(moc);
   }
 
   handleAutoFillMember(govId) {
@@ -281,7 +281,7 @@ UserToolkit.propTypes = {
   addMemberLink: PropTypes.func.isRequired,
   eventCount: PropTypes.number,
   currentTownHall: PropTypes.shape({}).isRequired,
-  getSelectedMemberInfo: PropTypes.func.isRequired,
+  setSelectedMember: PropTypes.func.isRequired,
   peopleDataUrl: PropTypes.string.isRequired,
   resetAllData: PropTypes.func.isRequired,
   requestPersonDataById: PropTypes.func.isRequired,
@@ -317,7 +317,7 @@ const mapDispatchToProps = dispatch => ({
   addMemberLink: payload => dispatch(lawMakerStateBranch.actions.addMemberLink(payload)),
   editMemberLink: payload => dispatch(lawMakerStateBranch.actions.editMemberLink(payload)),
   deleteMemberLink: payload => dispatch(lawMakerStateBranch.actions.deleteMemberLink(payload)),
-  getSelectedMemberInfo: member => dispatch(lawMakerStateBranch.actions.getSelectedMemberInfo(member)),
+  setSelectedMember: member => dispatch(lawMakerStateBranch.actions.setSelectedMember(member)),
   submitMetaData: payload => dispatch(townHallStateBranch.actions.saveMetaData(payload)),
   setSelectedLink: payload => dispatch(lawMakerStateBranch.actions.setSelectedLink(payload)),
 });

--- a/src/state/members-candidates/actions.js
+++ b/src/state/members-candidates/actions.js
@@ -34,7 +34,7 @@ const deleteLink = payload => ({
   type: 'DELETE_LINK',
 });
 
-const setSelectedMember = payload => ({
+export const setSelectedMember = payload => ({
   payload,
   type: 'SET_SELECTED_MEMBER',
 });
@@ -88,17 +88,6 @@ export const requestAdditionalPersonDataById = (peopleDataUrl, id, index) => dis
     return dispatch(setAdditionalMember(member));
   })
   .catch(console.log);
-
-export const getSelectedMemberInfo = payload => (dispatch) => {
-  firebasedb.ref(`mocData/${payload.govtrack_id}/helpful_links`).once('value').then((snapshot) => {
-    const links = snapshot.val();
-    for (const prop in links) {
-      links[prop].id = prop;
-    }
-    payload.moc_links = links;
-    dispatch(setSelectedMember(payload));
-  });
-};
 
 export const addMemberLink = payload => (dispatch) => {
   if (payload.link_title && payload.link_url) {

--- a/src/state/members-candidates/reducers.js
+++ b/src/state/members-candidates/reducers.js
@@ -43,7 +43,7 @@ const peopleReducer = (state = initialState, {
         ...state,
         selectedMember: {
           ...state.selectedMember,
-          moc_links: set(state.selectedMember.moc_links ? state.selectedMember.moc_links : {}, `${payload.id}`, { id: payload.id, ...payload.link })
+          helpful_links: set(state.selectedMember.helpful_links ? state.selectedMember.helpful_links : {}, `${payload.id}`, { id: payload.id, ...payload.link })
         }
       }
     case 'EDIT_LINK':
@@ -51,7 +51,7 @@ const peopleReducer = (state = initialState, {
         ...state,
         selectedMember: {
           ...state.selectedMember,
-          moc_links: mapValues(state.selectedMember.moc_links, (link) => {
+          helpful_links: mapValues(state.selectedMember.helpful_links, (link) => {
             if (link.id === payload.link_id) {
               return { id: payload.link_id, ...payload.linkInfo };
             }
@@ -64,7 +64,7 @@ const peopleReducer = (state = initialState, {
         ...state,
         selectedMember: {
           ...state.selectedMember,
-          moc_links: omit(state.selectedMember.moc_links, [`${payload.link_id}`])
+          helpful_links: omit(state.selectedMember.helpful_links, [`${payload.link_id}`])
         }
       }
     default:

--- a/src/state/selections/selectors.js
+++ b/src/state/selections/selectors.js
@@ -71,9 +71,9 @@ export const getSaveUrl = createSelector([getSelectedUSState], (usState) => {
 export const getSelectedUserMoc = createSelector([getSelectedMemberId, getUserMOCs], (selectedId, userMocs) => find(userMocs, moc => moc.id === selectedId));
 
 export const getSelectedMemberLinks = createSelector([getSelectedUserMoc], (selectedMember) => {
-  if (selectedMember && selectedMember.moc_links) {
-    return Object.keys(selectedMember.moc_links).map((key) => {
-      const link = selectedMember.moc_links[key];
+  if (selectedMember && selectedMember.helpful_links) {
+    return Object.keys(selectedMember.helpful_links).map((key) => {
+      const link = selectedMember.helpful_links[key];
       return {
         id: key,
         ...link,


### PR DESCRIPTION
This update reduces the number of retrievals from the db by changing the selectMoc function to grab moc from reducer instead of db endpoint. 

It also helps standardize the naming for our 'helpful_links' which were named two things before unnecessarily --> 'moc_links' and 'hepful_links' causing confusion.

This is a work in progress towards eliminating unnecessary db calls.

Next TODO: autofill form data from userMocs instead of another db call.