### PR TITLE
Add custom member form

### DIFF
--- a/src/components/MemberForm/customMemberForm.js
+++ b/src/components/MemberForm/customMemberForm.js
@@ -11,18 +11,18 @@ import {
 } from 'antd';
 
 import states from '../../data/states';
-import { formItemLayout, MOC_MODE } from '../../constants';
+import { formItemLayout } from '../../constants';
 
 const { Option } = Select;
 const FormItem = Form.Item;
 
 const customMemberForm = (props) => {
   const {
-    selectedUSState,
     getFieldValue,
     getFieldDecorator,
+    resetAllData,
+    selectedUSState,
     setGenericTownHallValue,
-    togglePersonMode,
   } = props;
 
   const onNameChange = (e) => {
@@ -32,6 +32,15 @@ const customMemberForm = (props) => {
       value,
     });
   };
+
+  const cancelCustomMember = () => {
+    const {
+      resetAllData,
+      clearSelectedMember,
+    } = props;
+    clearSelectedMember()
+    resetAllData()
+  }
 
   const renderDistrict = () => selectedUSState ? (
         <FormItem
@@ -164,7 +173,7 @@ const customMemberForm = (props) => {
         )}
       </FormItem>
       <FormItem>
-        <Button type="dashed" onClick={() => togglePersonMode(MOC_MODE)}>
+        <Button type="dashed" onClick={() => cancelCustomMember()}>
           <Icon type="minus-circle-o" /> Cancel add new lawmaker
         </Button>
       </FormItem>

--- a/src/components/MemberForm/customMemberForm.js
+++ b/src/components/MemberForm/customMemberForm.js
@@ -2,13 +2,16 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { map } from 'lodash';
 import {
-  Input,
-  Select,
+  Button,
   Form,
+  Icon,
+  Input,
+  Radio,
+  Select,
 } from 'antd';
 
 import states from '../../data/states';
-import { formItemLayout } from '../../constants';
+import { formItemLayout, MOC_MODE } from '../../constants';
 
 const { Option } = Select;
 const FormItem = Form.Item;
@@ -19,7 +22,9 @@ const customMemberForm = (props) => {
     getFieldValue,
     getFieldDecorator,
     setGenericTownHallValue,
+    togglePersonMode,
   } = props;
+
   const onNameChange = (e) => {
     const { value } = e.target;
     setGenericTownHallValue({
@@ -158,8 +163,12 @@ const customMemberForm = (props) => {
           </Select>,
         )}
       </FormItem>
+      <FormItem>
+        <Button type="dashed" onClick={() => togglePersonMode(MOC_MODE)}>
+          <Icon type="minus-circle-o" /> Cancel add new lawmaker
+        </Button>
+      </FormItem>
     </React.Fragment>
-
   );
 };
 

--- a/src/components/MemberForm/index.js
+++ b/src/components/MemberForm/index.js
@@ -276,6 +276,17 @@ class MemberLookup extends React.Component {
     });
   }
 
+  addCustomMember = () => {
+    const {
+      clearSelectedMember,
+      togglePersonMode,
+      resetAllData,
+    } = this.props
+    clearSelectedMember();
+    resetAllData();
+    togglePersonMode(MANUAL_MODE);
+  }
+
   memberForms() {
     const {
       getFieldValue,
@@ -371,7 +382,7 @@ class MemberLookup extends React.Component {
         <FormItem
           extra="Please first check if the individual already exists in our system"
         >
-          <Button type="dashed" onClick={() => this.props.togglePersonMode(MANUAL_MODE)} style={{ width: '60%' }}>
+          <Button type="dashed" onClick={() => this.addCustomMember()} style={{ width: '60%' }}>
             <Icon type="plus" /> Add new lawmaker
           </Button>
         </FormItem>
@@ -416,13 +427,14 @@ class MemberLookup extends React.Component {
 
   render() {
     const {
-      personMode,
+      clearSelectedMember,
       currentTownHall,
-      selectedUSState,
       getFieldValue,
       getFieldDecorator,
+      personMode,
+      resetAllData,
+      selectedUSState,
       setGenericTownHallValue,
-      togglePersonMode,
     } = this.props;
 
     getFieldDecorator('formKeys', {
@@ -462,12 +474,13 @@ class MemberLookup extends React.Component {
 
         {personMode === 'manual'
         ? <CustomMemberForm
+          clearSelectedMember={clearSelectedMember}
           currentTownHall={currentTownHall}
           getFieldDecorator={getFieldDecorator}
           getFieldValue={getFieldValue}
+          resetAllData={resetAllData}
           selectedUSState={selectedUSState}
           setGenericTownHallValue={setGenericTownHallValue}
-          togglePersonMode={togglePersonMode}
         />
         : this.memberForms()}
       </section>

--- a/src/components/MemberForm/index.js
+++ b/src/components/MemberForm/index.js
@@ -6,13 +6,12 @@ import {
   AutoComplete,
   Input,
   Form,
-  Radio,
   Icon,
   Button,
   Modal,
 } from 'antd';
 import { find } from 'lodash';
-import renderCustomPersonForm from './customMemberForm';
+import CustomMemberForm from './customMemberForm';
 
 import './style.scss';
 import {
@@ -324,7 +323,7 @@ class MemberLookup extends React.Component {
           <br />
         </h4>
         <FormItem
-          extra="Enter their name and we will auto-fill the information"
+          extra="Enter their name and we will auto-fill their information"
           validateStatus={(getError('displayName') || peopleLookUpError) ? 'error' : ''}
           help={getError('displayName') || peopleLookUpError || ''}
         >
@@ -365,6 +364,16 @@ class MemberLookup extends React.Component {
               </div>,
             )}
 
+        </FormItem>
+        <h5>
+          If you are unable to find the lawmaker or candidate you are looking for, you may request to add a new individual to the system.
+        </h5>
+        <FormItem
+          extra="Please first check if the individual already exists in our system"
+        >
+          <Button type="dashed" onClick={() => this.props.togglePersonMode(MANUAL_MODE)} style={{ width: '60%' }}>
+            <Icon type="plus" /> Add new lawmaker
+          </Button>
         </FormItem>
         <FormItem>
           {this.renderOptions()}
@@ -413,6 +422,7 @@ class MemberLookup extends React.Component {
       getFieldValue,
       getFieldDecorator,
       setGenericTownHallValue,
+      togglePersonMode,
     } = this.props;
 
     getFieldDecorator('formKeys', {
@@ -442,23 +452,24 @@ class MemberLookup extends React.Component {
 
     return (
       <section className="member-info">
-        {personMode === 'manual' ? renderCustomPersonForm(
-          {
-            currentTownHall,
-            getFieldDecorator,
-            getFieldValue,
-            selectedUSState,
-            setGenericTownHallValue,
-          },
-        ) : this.memberForms()}
-
         {/* <div className="district-group federal-district-group" id="federal-district-group">
-          <FormItem>
-            <Button type="dashed" onClick={this.addMember} style={{ width: '60%' }}>
-              <Icon type="plus" /> Add another lawmaker
-            </Button>
-          </FormItem>
-        </div> */}
+           <FormItem>
+             <Button type="dashed" onClick={this.addMember} style={{ width: '60%' }}>
+               <Icon type="plus" /> Add another lawmaker
+             </Button>
+           </FormItem>
+         </div> */}
+
+        {personMode === 'manual'
+        ? <CustomMemberForm
+          currentTownHall={currentTownHall}
+          getFieldDecorator={getFieldDecorator}
+          getFieldValue={getFieldValue}
+          selectedUSState={selectedUSState}
+          setGenericTownHallValue={setGenericTownHallValue}
+          togglePersonMode={togglePersonMode}
+        />
+        : this.memberForms()}
       </section>
     );
   }

--- a/src/containers/FormController/index.js
+++ b/src/containers/FormController/index.js
@@ -131,12 +131,14 @@ class FormController extends React.Component {
       resetTownHallData,
       resetFormKeys,
       clearTempAddress,
+      clearMemberCandidateMode,
     } = this.props;
     this.setState({
       displayValues: null,
       errors: null,
     });
     resetFormKeys();
+    clearMemberCandidateMode();
     clearTempAddress();
     resetTownHallData();
   }
@@ -293,6 +295,7 @@ const mapDispatchToProps = dispatch => ({
   addDisclaimer: () => dispatch(townHallStateBranch.actions.addDisclaimer()),
   getAllEventToCheckDups: (liveUrl, submissionUrl) => dispatch(allTownHallsStateBranch.actions.getAllEventToCheckDups(liveUrl, submissionUrl)),
   clearDisclaimer: () => dispatch(townHallStateBranch.actions.clearDisclaimer()),
+  clearMemberCandidateMode: () => dispatch(selectionStateBranch.actions.clearMemberCandidateMode()),
   clearTempAddress: () => dispatch(selectionStateBranch.actions.clearTempAddress()),
   resetFormKeys: () => dispatch(selectionStateBranch.actions.resetFormKeys()),
   resetTownHallData: () => dispatch(townHallStateBranch.actions.resetTownHall()),

--- a/src/containers/MainForm/index.jsx
+++ b/src/containers/MainForm/index.jsx
@@ -236,6 +236,7 @@ class MainForm extends React.Component {
       togglePersonMode,
       selectedUSState,
       geoCodeLocation,
+      resetAllData,
       resetDatabaseLookupError,
       requiredFields,
       setLatLng,
@@ -284,6 +285,7 @@ class MainForm extends React.Component {
             setDataFromPersonInDatabaseAction={setDataFromPersonInDatabaseAction}
             requestPersonDataById={requestPersonDataById}
             requestAdditionalPersonDataById={requestAdditionalPersonDataById}
+            resetAllData={resetAllData}
             selectedUSState={selectedUSState}
             togglePersonMode={togglePersonMode}
             getFieldDecorator={getFieldDecorator}


### PR DESCRIPTION
Connect the custom member form into the member form and main form.
Users can hit a button to toggle between adding a custom member or selecting a member from the database. Users are first encouraged to check the database. This PR does not check if a custom member already exists in the database. If users toggle between custom member form and regular member form, the event information resets.
![Screen Shot 2020-03-25 at 12 38 55 PM](https://user-images.githubusercontent.com/44733961/77578707-416c7c80-6e96-11ea-8fb0-cd83599ccc58.png)
View once custom form is selected:
![Screen Shot 2020-03-25 at 12 39 07 PM](https://user-images.githubusercontent.com/44733961/77578989-ba6bd400-6e96-11ea-9874-666345d1308d.png)

@meganrm 
