### PR TITLE
Fix duplicate warning not displaying

### DIFF
--- a/src/containers/FormController/index.js
+++ b/src/containers/FormController/index.js
@@ -116,7 +116,7 @@ class FormController extends React.Component {
     if (match && (target[date] == search[date] && target[time] == search[time])) {
       dupe = true;
     }
-    return (dupe);
+    return dupe;
   }
 
   checkForDupes(currentEvent) {


### PR DESCRIPTION
This PR addresses issue [#688](https://github.com/townhallproject/townHallProject/issues/688).

Update to return boolean from duplicateCheck() function, which now correctly displays warning for possible repeat events.

@meganrm 